### PR TITLE
Add a newline at the end of a gzipped tsv file

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/s3/serializers/GZipSerializer.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/s3/serializers/GZipSerializer.scala
@@ -44,17 +44,14 @@ object GZipSerializer extends ISerializer {
     val outputStream = new ByteArrayOutputStream()
     val gzipOutputStream = new GZIPOutputStream(outputStream, 64 * 1024)
 
-    var prefix = Array[Byte]()
-
     // Populate the output stream with records
     // TODO: Should there be a check for failures?
     val results = for { 
       Success(record) <- records 
     } yield {
       try {
-        gzipOutputStream.write(prefix)
         gzipOutputStream.write(record)
-        prefix = "\n".getBytes
+        gzipOutputStream.write("\n".getBytes)
         record.success
       } catch {
         case e: IOException => {


### PR DESCRIPTION
Missing newline at the end of tsv file made spark not to read the last event from each file.
