### PR TITLE
Resolve environment variables in hocon

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/s3/SinkApp.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/s3/SinkApp.scala
@@ -71,7 +71,7 @@ object SinkApp extends App {
 
       val file = new File(c)
       if (file.exists) {
-        ConfigFactory.parseFile(file)
+        ConfigFactory.parseFile(file).resolve()
       } else {
         parser.usage("Configuration file \"%s\" does not exist".format(c))
         ConfigFactory.empty()


### PR DESCRIPTION
Allows the using 
`stream-name: "my-stream-"${STREAM_POSTFIX}` in config files so that environment variables can be substituted into them:

`STREAM_POSTFIX="production" /opt/snowplow/snowplow-kinesis-s3 --config /opt/snowplow/scala-kinesis-s3.conf`
