### PR TITLE
Resolve substitutions in configuration file.

### DIFF
--- a/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/s3/SinkApp.scala
+++ b/src/main/scala/com.snowplowanalytics.snowplow.storage.kinesis/s3/SinkApp.scala
@@ -71,7 +71,7 @@ object SinkApp extends App {
 
       val file = new File(c)
       if (file.exists) {
-        ConfigFactory.parseFile(file)
+        ConfigFactory.parseFile(file).resolve()
       } else {
         parser.usage("Configuration file \"%s\" does not exist".format(c))
         ConfigFactory.empty()


### PR DESCRIPTION
Currently, substitutions such as `sink.kinesis.in.stream-name: ${IN_STREAM_NAME}` are not resolved to environment variables or system properties in the configuration file. This makes it difficult to deploy kinesis-s3 in different environments without having a separate configuration file for each environment.

To be able to resolve substitutions in the configuration file, a call to Config.resolve() should be added. The solution is equivalent to, for example, Snowplow's [Scala Stream Collector](https://github.com/snowplow/snowplow/blob/cb3920ee69f20293fd518f77854f1f956ca44aea/2-collectors/scala-stream-collector/src/main/scala/com.snowplowanalytics.snowplow.collectors/scalastream/ScalaCollectorApp.scala#L71).